### PR TITLE
增加自动生成字面量按钮

### DIFF
--- a/src/main/java/com/plugins/mybaitslog/console/ConsoleActionGroup.java
+++ b/src/main/java/com/plugins/mybaitslog/console/ConsoleActionGroup.java
@@ -1,6 +1,7 @@
 package com.plugins.mybaitslog.console;
 
 import com.intellij.icons.AllIcons;
+import com.intellij.icons.AllIcons.Actions;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.ToggleAction;
@@ -58,6 +59,25 @@ public class ConsoleActionGroup {
         @Override
         public void setSelected(@NotNull AnActionEvent anActionEvent, boolean b) {
             SqlProUtil.Ellipsis = b;
+        }
+    }
+
+    /**
+     * Sql 展示字面量按钮
+     */
+    public static class ShowLiteralAction extends ToggleAction implements DumbAware{
+
+        public ShowLiteralAction(){
+            super("Literal","ShowLiteral", Actions.ShowCode);
+        }
+        @Override
+        public boolean isSelected(@NotNull AnActionEvent anActionEvent) {
+            return SqlProUtil.ShowLiteral;
+        }
+
+        @Override
+        public void setSelected(@NotNull AnActionEvent anActionEvent, boolean b) {
+            SqlProUtil.ShowLiteral = b;
         }
     }
 }

--- a/src/main/java/com/plugins/mybaitslog/console/ConsolePanel.java
+++ b/src/main/java/com/plugins/mybaitslog/console/ConsolePanel.java
@@ -94,6 +94,7 @@ public class ConsolePanel {
         });
         actionGroup.add(new ConsoleActionGroup.FilterAction());
         actionGroup.add(new ConsoleActionGroup.FormatAction());
+        actionGroup.add(new ConsoleActionGroup.ShowLiteralAction());
         actionGroup.add(consoleView.createConsoleActions()[2]);
         actionGroup.add(consoleView.createConsoleActions()[3]);
         actionGroup.add(consoleView.createConsoleActions()[5]);

--- a/src/main/java/com/plugins/mybaitslog/type/JavaType.java
+++ b/src/main/java/com/plugins/mybaitslog/type/JavaType.java
@@ -1,0 +1,47 @@
+package com.plugins.mybaitslog.type;
+
+/**
+ * Java 数据类型
+ *
+ * @author St.kai
+ * @date 2021-09-05 03:41
+ * @since 2.0.5
+ */
+public enum JavaType {
+    String(false, null),
+    Date(true, LiteralType.DATE),
+    Time(true, LiteralType.TIME),
+    Timestamp(true, LiteralType.TIMESTAMP),
+    LocalDate(true, LiteralType.DATE),
+    LocalTime(true, LiteralType.TIME),
+    LocalDateTime(true, LiteralType.TIMESTAMP);
+    /**
+     * 是否显示字面量
+     */
+    private final boolean showLiteral;
+    /**
+     * 字面量名称
+     */
+    private final String literalName;
+
+    JavaType(boolean showLiteral, String literalName) {
+        this.showLiteral = showLiteral;
+        this.literalName = literalName;
+    }
+
+
+    public boolean isShowLiteral() {
+        return showLiteral;
+    }
+
+    public String getLiteralName() {
+        return literalName;
+    }
+}
+
+class LiteralType {
+
+    protected static final String DATE = "date";
+    protected static final String TIME = "time";
+    protected static final String TIMESTAMP = "timestamp";
+}

--- a/src/main/java/com/plugins/mybaitslog/util/SqlProUtil.java
+++ b/src/main/java/com/plugins/mybaitslog/util/SqlProUtil.java
@@ -1,7 +1,8 @@
 package com.plugins.mybaitslog.util;
 
-import com.intellij.openapi.project.Project;
+import com.plugins.mybaitslog.type.JavaType;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.EnumUtils;
 
 import java.util.*;
 import java.util.regex.Matcher;
@@ -31,6 +32,7 @@ public class SqlProUtil {
     private final static Pattern PSubstring = Pattern.compile(Separate_Substring);
 
     public static Boolean Ellipsis = false;
+    public static Boolean ShowLiteral= false;
 
     /**
      * 获取Sql语句类型
@@ -199,11 +201,12 @@ public class SqlProUtil {
      * @return String
      */
     private static String quotationTypeFormat(String[] parametersTypeOrValue) {
-        String[] d = {"String", "Timestamp", "Date", "Time", "LocalDate", "LocalTime", "LocalDateTime"};
-        for (String s : d) {
-            if (s.equals(parametersTypeOrValue[1])) {
-                return String.format("'%s'", parametersTypeOrValue[0]);
+        if (EnumUtils.isValidEnumIgnoreCase(JavaType.class, parametersTypeOrValue[1])) {
+            JavaType javaType = EnumUtils.getEnumIgnoreCase(JavaType.class, parametersTypeOrValue[1]);
+            if (SqlProUtil.ShowLiteral && javaType.isShowLiteral()) {
+                return String.format("%s'%s'", javaType.getLiteralName(), parametersTypeOrValue[0]);
             }
+            return String.format("'%s'", parametersTypeOrValue[0]);
         }
         return parametersTypeOrValue[0];
     }


### PR DESCRIPTION
Oracle 不能自动转换不含字面量类型的字符串,生成的SQL不能直接执行,所以增加了一个自动生成字面量类型的按钮  
例如:mybatis参数为 `2021-09-06 01:01:01.000001(Timestamp), 01:01:01(Time)`自动添加字面量后生成的SQL为`timestamp'2021-09-06 01:01:01.000001' , time'01:01:01' `
